### PR TITLE
Update CLI application name

### DIFF
--- a/src/main/java/ch/heig/gen/MainCommand.java
+++ b/src/main/java/ch/heig/gen/MainCommand.java
@@ -2,11 +2,10 @@ package ch.heig.gen;
 
 import picocli.CommandLine;
 
-//TODO : Donner un nom et une description a la commande et aux sous commandes
 @CommandLine.Command(
-        name = "testCommand",
+        name = "arancia",
         subcommands = {NewCommand.class, CleanCommand.class, BuildCommand.class, ServeCommand.class},
-        description = "Not implemented",
+        description = "Description stub.",
         mixinStandardHelpOptions = true,
         version = "1")
 public class MainCommand {


### PR DESCRIPTION
As per last week's discussion we decided to name it _Arancia_ while we find a better name. This commit makes it coherent with the rest of the project (README, POM, ...).

Additionally removed `TODO` note in code:

> A TODO note should include their responsible (e.g. `TODO(@Roos)`) and a reason why such note cannot be inmediately fixed.

In the case of a missing feature, it's a better idea to add it to the issue tracker. Comments are not checked and subject to bitrot...