### PR TITLE
CI: Use official docker maven image instead of github's magical java build.

### DIFF
--- a/.github/workflows/maven-publish.yml
+++ b/.github/workflows/maven-publish.yml
@@ -11,14 +11,11 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    container: maven:3-openjdk-11-slim
     steps:
       - uses: actions/checkout@v2
       - name: Welcome
         run: echo "Checking contribution..."
-      - name: Set up JDK 11
-        uses: actions/setup-java@v1
-        with:
-          java-version: 11
       - name: Cache Maven packages
         uses: actions/cache@v2
         with:

--- a/.github/workflows/maven-publish.yml
+++ b/.github/workflows/maven-publish.yml
@@ -26,4 +26,4 @@ jobs:
           key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
           restore-keys: ${{ runner.os }}-m2
       - name: Build with Maven
-        run: mvn --batch-mode --update-snapshots verify
+        run: mvn verify --batch-mode --update-snapshots --errors --fail-at-end --show-version


### PR DESCRIPTION
See commit messages.